### PR TITLE
Refactor guts into gatt_core

### DIFF
--- a/PyBT/gatt_core.py
+++ b/PyBT/gatt_core.py
@@ -4,6 +4,10 @@ import select
 import functools
 import threading
 import gevent
+from gevent.select import select
+# this is hack because the above does not work
+from gevent import monkey
+monkey.patch_select()
 
 from PyBT.gap import GAP
 from PyBT.stack import BTEvent

--- a/PyBT/gatt_core.py
+++ b/PyBT/gatt_core.py
@@ -105,12 +105,10 @@ class Connection(object):
     # Public command functions
 
     def scan(self, arg):
-        sys.stderr.write("entering scan\n")
         if arg == 'on':
             self.central.stack.scan()
         else:
             self.central.stack.scan_stop()
-        sys.stderr.write("exiting scan\n")
 
     def connect(self, addr, kind=None):
         if kind is None:

--- a/PyBT/gatt_core.py
+++ b/PyBT/gatt_core.py
@@ -1,6 +1,6 @@
 import sys
 import errno
-import select
+import select as native_select
 import functools
 import threading
 import gevent
@@ -46,8 +46,8 @@ class SocketHandler(object):
         seen = self.conn.seen
         while True:
             try:
-                select.select([self.conn.central.stack], [], [])
-            except select.error as ex:
+                select([self.conn.central.stack], [], [])
+            except native_select.error as ex:
                 if ex[0] == errno.EINTR:
                     continue
                 raise
@@ -105,10 +105,12 @@ class Connection(object):
     # Public command functions
 
     def scan(self, arg):
+        sys.stderr.write("entering scan\n")
         if arg == 'on':
             self.central.stack.scan()
         else:
             self.central.stack.scan_stop()
+        sys.stderr.write("exiting scan\n")
 
     def connect(self, addr, kind=None):
         if kind is None:

--- a/PyBT/gatt_core.py
+++ b/PyBT/gatt_core.py
@@ -1,0 +1,145 @@
+import sys
+import errno
+import select
+import functools
+import threading
+import gevent
+
+from PyBT.gap import GAP
+from PyBT.stack import BTEvent
+
+
+def needs_connection(func):
+    @functools.wraps(func)
+    def inner(self, *args):
+        if not self.connected:
+            raise ConnectionError("This command requires a connection")
+        return func(self, *args)
+    return inner
+
+
+class ConnectionError(Exception):
+    pass
+
+
+class SocketHandler(object):
+    def __init__(self, conn):
+        self.conn = conn
+
+    def dump_gap(self, data):
+        if len(data) > 0:
+            try:
+                gap = GAP()
+                gap.decode(data)
+                print "GAP: %s" % gap
+            except Exception as e:
+                print e
+                pass
+
+    # Make this look a bit like a thread.
+    def run(self):
+        # FIXME(richo) Mutex around shared mutable state
+        seen = self.conn.seen
+        while True:
+            try:
+                select.select([self.conn.central.stack], [], [])
+            except select.error as ex:
+                if ex[0] == errno.EINTR:
+                    continue
+                raise
+
+            event = self.conn.central.stack.handle_data()
+            if event.type == BTEvent.SCAN_DATA:
+                addr, type, data = event.data
+                print ("Saw %s (%s)" %
+                       (addr, "public" if type == 0 else "random"))
+                if addr in seen:
+                    if len(data) > len(seen[addr][1]):
+                        seen[addr] = (type, data)
+                        self.dump_gap(data)
+                else:
+                    seen[addr] = (type, data)
+                    self.dump_gap(data)
+
+            elif event.type == BTEvent.CONNECTED:
+                # FIXME(richo) Mutex
+                self.conn.connected = True
+                print "Connected!"
+                if len(self.conn.onconnect) > 0:
+                    print "Running onconnect comands"
+                    while self.conn.onconnect():
+                        cmd = self.conn.onconnect(0)
+                        cmd()
+            elif event.type == BTEvent.DISCONNECTED:
+                self.conn.connected = False
+                print "Disconnected"
+
+            elif event.type == BTEvent.ATT_DATA:
+                pkt = event.data
+                # ack handle value notification
+                if pkt.opcode == 0x1d:
+                    self.central.stack.raw_att("\x1e")
+                print event
+            elif event.type != BTEvent.NONE:
+                print event
+
+
+class Connection(object):
+    def __init__(self, central):
+        self.connected = False
+        self.central = central
+        self.seen = {}
+        self.onconnect = []
+
+    def start(self):
+        self._dispatchSocketHandler()
+
+    def _dispatchSocketHandler(self):
+        handler = SocketHandler(self)
+        gevent.spawn(handler.start)
+
+    # Public command functions
+
+    def scan(self, arg):
+        if arg == 'on':
+            self.central.stack.scan()
+        else:
+            self.central.stack.scan_stop()
+
+    def connect(self, addr, kind=None):
+        if kind is None:
+            # We may have inferred it's kind from seeing it advertising
+            kind = self.seen.get(addr, (None,))[0]
+
+        if kind is None:
+            print "Error: please give address type"
+        else:
+            print "Connecting.."
+            self.central.stack.connect(addr, kind)
+
+    def quit(self):
+        # FIXME(richo) Actually do some cleanup, try to put the hci device back
+        # together
+        sys.exit(0)
+
+    @needs_connection
+    def write_req(self, handle, value):
+        self.central.att.write_req(handle=handle, value=value)
+
+    @needs_connection
+    def write_cmd(self, handle, value):
+        self.central.att.write_cmd(handle=handle, value=value)
+
+    @needs_connection
+    def read(self, handle):
+        self.central.att.read(handle)
+
+    def set_interval(self, int_min, int_max):
+        self.central.stack.interval_min = int_min
+        self.central.stack.interval_max = int_max
+
+    def on_connect(self, thunk):
+        self.onconnect.append(thunk)
+
+    def raw(self, cmd):
+        self.central.stack.raw_att(cmd)

--- a/PyBT/gatt_core.py
+++ b/PyBT/gatt_core.py
@@ -100,7 +100,7 @@ class Connection(object):
 
     def _dispatchSocketHandler(self):
         handler = SocketHandler(self)
-        gevent.spawn(handler.start)
+        gevent.spawn(handler.run)
 
     # Public command functions
 

--- a/PyBT/gattclient.py
+++ b/PyBT/gattclient.py
@@ -163,7 +163,8 @@ def runsource_with_connection(connection):
                 parts.pop(0)
             # FIXME(richo) Find out what version gives short syntax
             args = parse_command(parts)
-            cmd = args.pop(0).replace('-', '_')
+            cmd = args[0].replace('-', '_')
+            args = args[1:]
         except UnknownCommand:
             # XXX uncomment me to make this into a python repl
             # return orig_runsource(self, source)
@@ -190,7 +191,7 @@ def main():
     connection.start()
 
     code.InteractiveConsole.runsource = runsource_with_connection(connection)
-    Thread(target=code.interact, local=locals()).start()
+    Thread(target=code.interact).start()
 
     gevent.wait()
 

--- a/PyBT/gattclient.py
+++ b/PyBT/gattclient.py
@@ -4,11 +4,9 @@ import code
 import argparse
 from threading import Thread
 import gevent
-from gevent.fileobject import FileObject
 from binascii import unhexlify
 from PyBT.roles import LE_Central
-from PyBT.stack import BTEvent
-from PyBT.gap import GAP
+from PyBT.gatt_core import Connection, ConnectionError
 
 from gevent.select import select
 # this is hack because the above does not work
@@ -19,7 +17,6 @@ DISCONNECTED = 0
 CONNECTED = 1
 
 central = None
-seen = {}
 state = DISCONNECTED
 onconnect = []
 
@@ -130,14 +127,6 @@ class CommandModule(object):
             return None
         return ('raw', data)
 
-    @staticmethod
-    def onconnect(*args):
-        subcommand = parse_command(args, False)
-        if subcommand[0] == 'onconnect':
-            raise InvalidCommand("Can't nest onconnects")
-        return ('onconnect', subcommand)
-
-
 COMMANDS = {
     'scan': CommandModule.scan,
     'connect': CommandModule.connect,
@@ -149,7 +138,8 @@ COMMANDS = {
     'onconnect': CommandModule.onconnect,
 }
 
-def parse_command(f, recurse=True):
+
+def parse_command(f):
     if len(f) == 0:
         return None
     cmd_name = f[0]
@@ -157,152 +147,63 @@ def parse_command(f, recurse=True):
         cmd = COMMANDS[cmd_name](*f[1:])
         return cmd
     except IndexError:
-        pass # Ignore people mushing return
+        pass  # Ignore people mushing return
     except KeyError as e:
         print "Error: Unknown command '%s'" % e.args[0]
         raise UnknownCommand("unknown: %s" % e.args[0])
     except InvalidCommand as e:
-        print(repr(e)) # TODO Deal more gracefully
+        print(repr(e))  # TODO Deal more gracefully
 
-def process_command(cmd):
-    global seen, state, onconnect
-
-    if cmd[0] == 'scan':
-        if cmd[1] == 'on':
-            central.stack.scan()
-        else:
-            central.stack.scan_stop()
-    elif cmd[0] == 'connect':
-        addr, type = cmd[1:3]
-        if type is None:
-            type = seen.get(addr, (None,))[0] # maybe we saw it when advertising
-        if type is None:
-            print "Error: please give address type"
-        else:
-            print "Connecting.."
-            central.stack.connect(addr, type)
-    elif cmd[0] == 'quit':
-        exit(0)
-    elif cmd[0] == 'write-req' or cmd[0] == 'write-cmd':
-        if state != CONNECTED:
-            print "Can only write when connected!"
-        else:
-            if cmd[0] == 'write-req':
-                central.att.write_req(handle=cmd[1], value=cmd[2])
-            else:
-                central.att.write_cmd(handle=cmd[1], value=cmd[2])
-    elif cmd[0] == 'read':
-        handle = cmd[1]
-        if state != CONNECTED:
-            print "Can only read when connected!"
-        else:
-            central.att.read(handle)
-    elif cmd[0] == 'interval':
-        central.stack.interval_min = cmd[1]
-        central.stack.interval_max = cmd[2]
-    elif cmd[0] == 'onconnect':
-        onconnect.append(cmd[1])
-    elif cmd[0] == 'eval':
-        try:
-            cmd[1]()
-        except Exception as e:
-            print "Error running eval'd code: %s" % e
-    elif cmd[0] == 'raw':
-        central.stack.raw_att(cmd[1])
-
-def command_handler():
-    while True:
-        sys.stdout.write('>>> ')
-        sys.stdout.flush()
-
-        select([sys.stdin], [], [])
-        line = sys.stdin.readline()
-
-        # handle commands
-        if len(line) == 0:
-            print
-            exit(0) # hack for control-D
-        line = line.strip()
-        cmd = parse_command(line.split())
-        if cmd is not None:
-            process_command(cmd)
-
-def dump_gap(data):
-    if len(data) > 0:
-        try:
-            gap = GAP()
-            gap.decode(data)
-            print "GAP: %s" % gap
-        except Exception as e:
-            print e
-            pass
 
 def socket_handler(central):
     global seen, state, onconnect
 
     # handle events
-    while True:
-        select([central.stack], [], [])
-        event = central.stack.handle_data()
-        if event.type == BTEvent.SCAN_DATA:
-            addr, type, data = event.data
-            print "Saw %s (%s)" % (addr, "public" if type == 0 else "random")
-            if addr in seen:
-                if len(data) > len(seen[addr][1]):
-                    seen[addr] = (type, data)
-                    dump_gap(data)
+
+
+def runsource_with_connection(connection):
+    # orig_runsource = code.InteractiveConsole.runsource
+
+    def runsource(self, source, filename='<input>',
+                  symbol='single', encode=True):
+        # Try parsing it as a gatt client thing, then fall back to python
+        debug("[-] %s" % repr(source.split()))
+        oncommand_hack = False
+        try:
+            parts = source.split()
+            if parts[0] == 'oncommand':
+                oncommand_hack = True
+                parts.pop(0)
+            # FIXME(richo) Find out what version gives short syntax
+            args = parse_command(parts)
+            cmd = args.pop(0).replace('-', '_')
+        except UnknownCommand:
+            # XXX uncomment me to make this into a python repl
+            # return orig_runsource(self, source)
+            return None
+
+        if cmd is not None:
+            debug("[-] %s(%s)" % (repr(cmd), repr(args)))
+            # FIXME(richo) Deal gracefully with the AttributeError
+            func = getattr(connection, cmd)
+            if oncommand_hack:
+                self.connection.oncommand(lambda: func(*args))
             else:
-                seen[addr] = (type, data)
-                dump_gap(data)
+                func(*args)
+    return runsource
 
-        elif event.type == BTEvent.CONNECTED:
-            state = CONNECTED
-            print "Connected!"
-            if len(onconnect) > 0:
-                print "Running onconnect comands"
-                for i in onconnect:
-                    process_command(i, central)
-                onconnect = []
-        elif event.type == BTEvent.DISCONNECTED:
-            state = DISCONNECTED
-            print "Disconnected"
-
-        elif event.type == BTEvent.ATT_DATA:
-            pkt = event.data
-            # ack handle value notification
-            if pkt.opcode == 0x1d:
-                central.stack.raw_att("\x1e")
-            print event
-        elif event.type != BTEvent.NONE:
-            print event
-
-
-orig_runsource = code.InteractiveConsole.runsource
-def runsource(self, source, filename='<input>', symbol='single', encode=True):
-    # Try parsing it as a gatt client thing, then fall back to python
-    debug("[-] %s" % repr(source.split()))
-    try:
-        cmd = parse_command(source.split())
-    except UnknownCommand:
-        # XXX uncomment me to make this into a python repl
-        # return orig_runsource(self, source)
-        return None
-
-    if cmd is not None:
-        debug("[-] %s" % repr(cmd))
-        process_command(cmd)
 
 def main():
-    global central
-
     parser = _argparser()
     args = parser.parse_args()
 
     central = LE_Central(adapter=args.interface)
-    gevent.spawn(socket_handler, central)
 
-    code.InteractiveConsole.runsource = runsource
-    Thread(target=code.interact, kwargs={'local': locals()}).start()
+    connection = Connection(central)
+    connection.start()
+
+    code.InteractiveConsole.runsource = runsource_with_connection(connection)
+    Thread(target=code.interact, local=locals()).start()
 
     gevent.wait()
 

--- a/PyBT/gattclient.py
+++ b/PyBT/gattclient.py
@@ -158,6 +158,8 @@ def runsource_with_connection(connection):
         oncommand_hack = False
         try:
             parts = source.split()
+            if len(parts) == 0:
+                return
             if parts[0] == 'oncommand':
                 oncommand_hack = True
                 parts.pop(0)

--- a/PyBT/gattclient.py
+++ b/PyBT/gattclient.py
@@ -8,18 +8,6 @@ from binascii import unhexlify
 from PyBT.roles import LE_Central
 from PyBT.gatt_core import Connection, ConnectionError
 
-from gevent.select import select
-# this is hack because the above does not work
-from gevent import monkey
-monkey.patch_select()
-
-DISCONNECTED = 0
-CONNECTED = 1
-
-central = None
-state = DISCONNECTED
-onconnect = []
-
 def debug(msg):
     if os.getenv("DEBUG"):
         sys.stdout.write(msg)
@@ -135,7 +123,6 @@ COMMANDS = {
     'write-cmd': CommandModule.write_cmd,
     'read': CommandModule.read,
     'interval': CommandModule.interval,
-    'onconnect': CommandModule.onconnect,
 }
 
 


### PR DESCRIPTION
This gives you enough primitives to run the gatt_client programmatically
without a repl

r? @mikeryan 

(Totally untested, wrote it on a flight to india)
